### PR TITLE
Fixed issue

### DIFF
--- a/NppJSONViewer/TreeBuilder.cpp
+++ b/NppJSONViewer/TreeBuilder.cpp
@@ -43,14 +43,14 @@ const char* FALSE_STR = "false";
 
 bool TreeBuilder::Null()
 {
-	return this->String(NULL_STR, sizeof(NULL_STR), true);
+	return this->String(NULL_STR, static_cast<SizeType>(strlen(NULL_STR)), true);
 }
 
 bool TreeBuilder::Bool(bool b)
 {
 	if (b)
-		return this->String(TRUE_STR, sizeof(TRUE_STR), true);
-	return this->String(FALSE_STR, sizeof(FALSE_STR), true);
+		return this->String(TRUE_STR, static_cast<SizeType>(strlen(TRUE_STR)), true);
+	return this->String(FALSE_STR, static_cast<SizeType>(strlen(FALSE_STR)), true);
 }
 
 bool TreeBuilder::Int(int i) { cout << "Int(" << i << ")" << endl; return true; }

--- a/NppJSONViewer/utils.h
+++ b/NppJSONViewer/utils.h
@@ -3,8 +3,8 @@
 #include <string>
 #include <Shlwapi.h>
 
-#define SSTR( x ) static_cast< std::ostringstream & >( \
-        ( std::ostringstream() << std::dec << x ) ).str()
+template<typename T>
+constexpr auto SSTR(T x) { return (std::ostringstream() << std::dec << x).str(); }
 
 EXTERN_C IMAGE_DOS_HEADER __ImageBase;
 


### PR DESCRIPTION

Fixed issue #43 

```const char* FALSE_STR = "false";```
`sizeof(NULL_STR)` give the size of pointer instead of the string (char array). So this issue may not be seen in 
x64 bit as `sizeof` pointer in x64 is 8 whereas 4 in x86.

Use `strlen` to get the length of the string.