### PR TITLE
Update appveyor.yml

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ image: Visual Studio 2019
 
 environment:
   matrix:
-  - PlatformToolset: v142
+  - PlatformToolset: v142_xp
 
 platform:
     - x64


### PR DESCRIPTION
I was getting a build error for PlatformToolSet v142. The proposed change is to move to v142_xp, which seems to work.