### PR TITLE
Error messages when non-JSON file is open

### DIFF
--- a/NppJSONViewer/NppJsonViewer/JsonViewDlg.cpp
+++ b/NppJSONViewer/NppJsonViewer/JsonViewDlg.cpp
@@ -164,11 +164,13 @@ void JsonViewDlg::DrawJsonTree()
     HTREEITEM rootNode = nullptr;
     rootNode           = m_hTreeView->InitTree();
 
+    const bool isJsonFile = m_Editor->IsJsonFile();
     const std::string txtForParsing = m_Editor->GetJsonText();
 
-    if (txtForParsing.empty())
+    if (!isJsonFile || txtForParsing.empty())
     {
         m_hTreeView->InsertNode(JSON_ERR_PARSE, NULL, rootNode);
+        m_Editor->MakeSelection(0, 0);
     }
     else
     {

--- a/NppJSONViewer/NppJsonViewer/JsonViewDlg.h
+++ b/NppJSONViewer/NppJsonViewer/JsonViewDlg.h
@@ -20,7 +20,7 @@ class JsonViewDlg : public DockingDlgInterface
     };
 
 public:
-    JsonViewDlg(HINSTANCE hIntance, const NppData &nppData, int nCmdId, std::shared_ptr<Setting> &pSetting);
+    JsonViewDlg(HINSTANCE hIntance, const NppData &nppData, int nCmdId, std::shared_ptr<Setting> &pSetting, const bool *pIsLoaded);
     virtual ~JsonViewDlg();
 
     void ShowDlg(bool bShow);
@@ -32,8 +32,8 @@ public:
     void      AppendNodeCount(HTREEITEM node, unsigned elementCount, bool bArray);
 
 private:
-    void DrawJsonTree();
-    void PopulateTreeUsingSax(HTREEITEM tree_root, const std::string &jsonText);
+    void DrawJsonTree(bool suppressErrorMsg = false);
+    std::wstring PopulateTreeUsingSax(HTREEITEM tree_root, const std::string &jsonText);
 
     void ValidateJson();
 
@@ -71,9 +71,10 @@ protected:
     virtual INT_PTR CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
 
 private:
-    int     m_nDlgId      = -1;
-    NppData m_NppData     = {};
-    HICON   m_hBtnIcon[4] = {};
+    int         m_nDlgId      = -1;
+    NppData     m_NppData     = {};
+    HICON       m_hBtnIcon[4] = {};
+    const bool *m_pIsLoaded   = nullptr;
 
     // To handle doc panel resizing
     LONG m_lfDeltaWidth          = 0;

--- a/NppJSONViewer/NppJsonViewer/NppJsonPlugin.cpp
+++ b/NppJSONViewer/NppJsonViewer/NppJsonPlugin.cpp
@@ -75,6 +75,8 @@ void NppJsonPlugin::ProcessNotification(const SCNotification *notifyCode)
         {
             ::SendMessage(m_pJsonViewDlg->getHSelf(), WM_COMMAND, IDC_BTN_REFRESH, 0);
         }
+        m_bIsLoaded = true;
+
         break;
     }
 
@@ -155,7 +157,7 @@ void NppJsonPlugin::ConstructJsonDlg()
     {
         ConstructSetting();
         auto nCmdId    = m_shortcutCommands.GetCommandID(CallBackID::SHOW_DOC_PANEL);
-        m_pJsonViewDlg = std::make_unique<JsonViewDlg>(reinterpret_cast<HINSTANCE>(m_hModule), m_NppData, nCmdId, m_pSetting);
+        m_pJsonViewDlg = std::make_unique<JsonViewDlg>(reinterpret_cast<HINSTANCE>(m_hModule), m_NppData, nCmdId, m_pSetting, &m_bIsLoaded);
     }
 }
 

--- a/NppJSONViewer/NppJsonViewer/NppJsonPlugin.h
+++ b/NppJSONViewer/NppJsonViewer/NppJsonPlugin.h
@@ -87,6 +87,7 @@ private:
     NppData                      m_NppData = {};
     std::wstring                 m_configPath;
     bool                         m_bAboutToClose = false;
+    bool                         m_bIsLoaded     = false;
     std::unique_ptr<AboutDlg>    m_pAboutDlg     = nullptr;
     std::unique_ptr<JsonViewDlg> m_pJsonViewDlg  = nullptr;
     std::unique_ptr<SettingsDlg> m_pSettingsDlg  = nullptr;


### PR DESCRIPTION
Fix: - Error when opening non-JSON file in Notepad++ while JSON Viewer Panel is active
      - Error when opening JSON Viewer Panel while non-JSON file is active
