### PR TITLE
Retrieve complete node value

### DIFF
--- a/NppJSONViewer/NppJsonViewer/TreeViewCtrl.cpp
+++ b/NppJSONViewer/NppJsonViewer/TreeViewCtrl.cpp
@@ -34,7 +34,7 @@ auto TreeViewCtrl::InsertNode(const std::wstring &text, LPARAM lparam, HTREEITEM
         tvinsert.hInsertAfter = TVI_LAST;
     }
 
-    if (text.length() + 1 > maxNodeTextLength)
+    if (text.length() + 1 > (size_t)maxNodeTextLength)
         maxNodeTextLength = (int)text.length() + 1;
 
     tvinsert.item.mask    = TVIF_HANDLE | TVIF_TEXT | TVIF_PARAM;

--- a/NppJSONViewer/NppJsonViewer/TreeViewCtrl.h
+++ b/NppJSONViewer/NppJsonViewer/TreeViewCtrl.h
@@ -7,6 +7,7 @@ class TreeViewCtrl
 {
     HWND m_hTree   = nullptr;
     HWND m_hParent = nullptr;
+    int  maxNodeTextLength = 0;
 
 public:
     TreeViewCtrl()  = default;


### PR DESCRIPTION
Fixes #172 "Copy value" / "Copy" not always return complete text