### PR TITLE
TreeHandler.h header file is included as ClCompile

### DIFF
--- a/src/NppJsonViewer/NPPJSONViewer.vcxproj
+++ b/src/NppJsonViewer/NPPJSONViewer.vcxproj
@@ -224,7 +224,7 @@
     <ClInclude Include="ShortcutCommand.h" />
     <ClInclude Include="SliderCtrl.h" />
     <ClInclude Include="StopWatch.h" />
-    <ClCompile Include="TreeHandler.h" />
+    <ClInclude Include="TreeHandler.h" />
     <ClInclude Include="TrackingStream.h" />
     <ClInclude Include="TreeViewCtrl.h" />
   </ItemGroup>

--- a/src/NppJsonViewer/NPPJSONViewer.vcxproj.filters
+++ b/src/NppJsonViewer/NPPJSONViewer.vcxproj.filters
@@ -57,9 +57,6 @@
     <ClCompile Include="..\..\external\npp\StaticDialog.cpp">
       <Filter>ThirdParty\npp</Filter>
     </ClCompile>
-    <ClCompile Include="TreeHandler.h">
-      <Filter>Header Files</Filter>
-    </ClCompile>
     <ClCompile Include="SliderCtrl.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -81,6 +78,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="ScintillaEditor.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="TreeHandler.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="TreeViewCtrl.h">


### PR DESCRIPTION
Header files must be ClInclude.
I think this was an accidental typo.
Make it ClInclude.